### PR TITLE
HTML was parsing in output

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -896,7 +896,7 @@
             public static function identifyTypeHTML( $arg, $recurseLevels=1 ) {
                 if ( ! is_array($arg) && !is_object($arg) ) {
                     if ( is_string($arg) ) {
-                        return "<span class='syntax-string'>\"$arg\"</span>";
+                        return "<span class='syntax-string'>" . htmlentities($arg) . "</span>";
                     } else {
                         return "<span class='syntax-literal'>" . var_export( $arg, true ) . '</span>';
                     }


### PR DESCRIPTION
If a session variable had HTML in it, it would parse and display as the decoded html.
