### PR TITLE
__DIR__ not in PHP <5.3

### DIFF
--- a/example/call_via_native.php
+++ b/example/call_via_native.php
@@ -1,5 +1,5 @@
 <?
-	require( __DIR__ . '/../src/php_error.php' );
+	require( dirname( __FILE__ ) . '/../src/php_error.php' );
 	\php_error\reportErrors();
 
 	$fun = function() {

--- a/example/class_not_found.php
+++ b/example/class_not_found.php
@@ -1,5 +1,5 @@
 <?php
-    require( __DIR__ . '/../src/php_error.php' );
+    require( dirname( __FILE__ ) . '/../src/php_error.php' );
     \php_error\reportErrors();
 
 	function a() {

--- a/example/js_injection.php
+++ b/example/js_injection.php
@@ -3,7 +3,7 @@
     $_SESSION['DKDKDK']='something';
 ?><!DOCTYPE html>
 <?php
-	require( __DIR__ . '/../src/php_error.php' );
+	require( dirname( __FILE__ ) . '/../src/php_error.php' );
 	\php_error\reportErrors();
 ?>
 

--- a/example/js_synchronous.php
+++ b/example/js_synchronous.php
@@ -1,5 +1,5 @@
 <?
-	require( __DIR__ . '/../src/php_error.php' );
+	require( dirname( __FILE__ ) . '/../src/php_error.php' );
 	\php_error\reportErrors();
 ?>
 

--- a/example/unknown_variable.php
+++ b/example/unknown_variable.php
@@ -1,5 +1,5 @@
 <?php
-    require( __DIR__ . '/../src/php_error.php' );
+    require( dirname( __FILE__ ) . '/../src/php_error.php' );
     \php_error\reportErrors();
 
 	function a() {

--- a/example/very_wide_stack.php
+++ b/example/very_wide_stack.php
@@ -1,5 +1,5 @@
 <?
-	require( __DIR__ . '/../src/php_error.php' );
+	require( dirname( __FILE__ ) . '/../src/php_error.php' );
 	\php_error\reportErrors();
 
 	function a() {

--- a/src/php_error.php
+++ b/src/php_error.php
@@ -258,7 +258,7 @@
                     'T_DEC'                         => '-- (decrement)',
                     'T_DECLARE'                     => 'declare',
                     'T_DEFAULT'                     => 'default',
-                    'T_DIR'                         => '__DIR__',
+                    'T_DIR'                         => 'dirname( __FILE__ )',
                     'T_DIV_EQUAL'                   => "'/='",
                     'T_DNUMBER'                     => 'number',
                     'T_DOLLAR_OPEN_CURLY_BRACES'    => '\'${\'',


### PR DESCRIPTION
The magic constant `__DIR__` isn't available with PHP <5.3

http://php.net/manual/en/language.constants.predefined.php
