### PR TITLE
Fix Session already set error. 

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -2396,7 +2396,7 @@
 
                     // load the session, if it's there
 
-                    if ( isset($_COOKIE[session_name()]) && session_id() !== '' ) {
+                    if ( isset($_COOKIE[session_name()]) && session_id() !== '' &&  !isset($_SESSION)) {
                         session_start();
                     }
 


### PR DESCRIPTION
Add another check to stop sessions being started twice. 

This happens when php-error is added to existing software that has already set the session. 
