### PR TITLE
session_start() throws warning if its already started before php_error is loaded.

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -2400,7 +2400,7 @@
                     // load the session, if it's there
 
                     if ( isset($_COOKIE[session_name()]) && session_id() !== '' &&  !isset($_SESSION)) {
-                        session_start();
+                        if(session_id() === ''){ session_start(); }
                     }
 
                     $request  = ErrorHandler::getRequestHeaders();


### PR DESCRIPTION
This change fixes that, and will still start the session if it isn't started.
