### PR TITLE
handle zlib output compression

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1510,6 +1510,7 @@
                         if ( $handler === 'ob_gzhandler' ) {
                             $wasGZHandler = true;
                             ob_end_clean();
+                        } else if ( $handler === 'zlib output compression' ) {
                         } else if ( $handler === 'default output handler' ) {
                             ob_end_clean();
                         } else {


### PR DESCRIPTION
The handler cleanup code would cause a warning with zlib output compression enabled. No need to flush at this point I think.
