### PR TITLE
Fix binary js injection

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -540,6 +540,15 @@
                         );
             }
 
+            private static function isBinaryRequest() {
+                $response = ErrorHandler::getResponseHeaders();
+                foreach ( $response as $key => $value ) {
+                    if ( strtolower($key) === 'content-transfer-encoding' ) {
+                      return strtolower($value) === 'binary';
+                    }
+                }
+            }
+
             /**
              * This attempts to state if this is *not* a PHP request,
              * but it cannot say if it *is* a PHP request. It achieves
@@ -1526,9 +1535,10 @@
                     }
 
                     if (
-                            !$this->isAjax &&
-                             $this->catchAjaxErrors &&
-                            (!$this->htmlOnly || !ErrorHandler::isNonPHPRequest())
+                        !$this->isAjax &&
+                         $this->catchAjaxErrors &&
+                         (!$this->htmlOnly || !ErrorHandler::isNonPHPRequest()) &&
+                         !ErrorHandler::isBinaryRequest()
                     ) {
                         $js = $this->getContent( 'displayJSInjection' );
                         $js = JSMin::minify( $js );
@@ -3157,6 +3167,7 @@
                     $requestUrl = $_SERVER['REQUEST_URI'];
                 }
 
+                header_remove('Content-Transfer-Encoding');
                 $this->displayHTML(
                         // pre, in the head
                         function() use( $message, $errFile, $errLine ) {


### PR DESCRIPTION
Added a static function isBinaryRequest() to test the Content-Transfer-Encoding header for the value 'binary' before injecting the JS snippet to prevent image PHP-generated images from getting corrupted.

Fixes #53
