### PR TITLE
Fixes for output buffer handling

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1521,7 +1521,7 @@
                         echo $content;
                     }
 
-                    ob_end_clean();
+                    ob_end_flush();
                     
                 }
             }


### PR DESCRIPTION
This pull simplifies and fixes buffer handling. If an error fires inside the buffer, it will be cleaned and canceled. 

It also keeps the buffer always running, including "outside" buffers, like gz_output and zlib.

If there is no error, it doesn't clean and rebuffer the output.
