### PR TITLE
Registering callbacks

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1135,6 +1135,8 @@
 
             private $classNotFoundException;
 
+            private $callbacks = array();
+            
             /**
              * = Options =
              * 
@@ -2355,6 +2357,12 @@
 
                 $this->logError( $message, $errFile, $errLine, $ex );
 
+                if ($this->triggerCallback( $code, $message, $errLine, $errFile, $ex )) {
+                    // exit in order to end processing
+                    $this->turnOff();
+                    exit(0);
+                }
+                
                 /**
                  * It runs if:
                  *  - it is globally enabled
@@ -2427,6 +2435,32 @@
                 }
             }
 
+            protected function triggerCallback( $code, $message, $errLine, $errFile, $ex=null ) {
+                foreach($this->callbacks as $callback) {
+                    if (call_user_func_array($callback, func_get_args())) return true;
+                }
+            }
+            
+            /** Adds a callback that will be called just right after logging 
+             * 
+             * Callback will receive the same arguments as reportError:
+             * callback($code, $message, $errLine, $errFile, $ex)
+             * 
+             * If the callback returns anything, no other callback will be called and the script
+             * will exit before displaying the error.
+             * 
+             */
+            public function addErrorCallback($callback) {
+                if (is_callable($callback) == false) throw new Exception('Callback not callable!');
+                $this->callbacks[] = $callback;
+            }
+            
+            public function removeErrorCallback($callback) {
+                $key = array_search($callback, $this->callbacks, true);
+                if ($key === false) throw new Exception('Callback not set!');
+                unset($this->callbacks[$key]);
+            }
+            
             private function getStackTrace( $ex, $code, $errFile, $errLine ) {
                 $stackTrace = null;
 


### PR DESCRIPTION
$handler->addErrorCallback() will add a callback that will be fired just right after logging the error.

It might be used to use additional loggers, or to display a nice error page for non-development users.

Returning anything from the callback will immediately stop processing the script (no error display).

The callback is of form:

``` php
callback( $code, $message, $errLine, $errFile, $ex )
```
