### PR TITLE
ErrorHandler::globalHandler() returns current handler

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1278,6 +1278,15 @@
                 $this->startBuffer();
             }
 
+            /** 
+             * Returns current global handler, or null if there is none.
+             * 
+             * @return ErrorHandler */
+            public static function globalHandler() {
+                global $_php_error_global_handler;
+                return $_php_error_global_handler;
+            }
+            
             /*
              * --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- --- ---
              * Public Functions


### PR DESCRIPTION
Use static function instead of playing with globals!
