### PR TITLE
Set of features to safely use PHP-Error on production environment

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1144,6 +1144,9 @@
             private $throwErrors;
             private $callbacks = array();
             private $errorPage;
+            private $errorLog;
+            private $errorLogFormat;
+            private $errorLogTimeFormat;
             
             
             /**
@@ -1204,6 +1207,23 @@
              *                              You can enabled it to throw errors instead.
              *  - error_page                Error page to show if display_errors is disabled.
              *                              Should be an absolute path to .html or .php file
+             * 
+             *  - error_log                 Defines where to log messages.
+             *                              FALSE - disables logging
+             *                              0 - logs to the syslog, equivalent of php's error_log($message, 0) (default)
+             *                              absolute path - logs to the provided file path, equivalent of php's error_log($message, 3, $path)
+             *                              email - sends an email, equivalent of php's error_log($message, 1, $email)
+             * 
+             *  - error_log_format          Format of log messages with printf() directives.
+             *                              %1$s - timestamp (empty if error_log is set to 0, because syslog is using it's own timestamp)
+             *                              %2$s - error message
+             *                              %3$s - file
+             *                              %4$s - line
+             *                              %5$s - stack trace (starts on the newline and is indented)
+             *                              Defaults to "%s%s\n           %s, %s %s"
+             *                              
+             *  - error_log_time_format     Format of log's timestamp compatible with strftime()
+             *                              Defaults to "[%c] "
              * 
              * @param options Optional, an array of values to customize this handler.
              * @throws Exception This is raised if given an options that does *not* exist (so you know that option is meaningless).
@@ -1268,6 +1288,10 @@
                 
                 $this->throwErrors              = !! ErrorHandler::optionsPop( $options, 'throw_errors', false );
                 $this->errorPage                = ErrorHandler::optionsPop( $options, 'error_page', false );
+
+                $this->errorLog                 = ErrorHandler::optionsPop( $options, 'error_log', 0 );
+                $this->errorLogFormat           = ErrorHandler::optionsPop( $options, 'error_log_format', "%s%s\n           %s, %s %s");
+                $this->errorLogTimeFormat       = ErrorHandler::optionsPop( $options, 'error_log_time_format', '[%c] ' );
 
                 $this->classNotFoundException   = null;
 
@@ -2293,17 +2317,25 @@
             }
 
             private function logError( $message, $file, $line, $ex=null ) {
+                if ($this->errorLog === false || !$this->errorLogFormat) return;
+                
+                $string = "";
+                $trace = "";
                 if ( $ex ) {
                     $trace = $ex->getTraceAsString();
                     $parts = explode( "\n", $trace );
-                    $trace = "        " . join( "\n        ", $parts );
-
-                    if ( ! ErrorHandler::isIIS() ) {
-                        error_log( "$message \n           $file, $line \n$trace" );
-                    }
-                } else {
-                    if ( ! ErrorHandler::isIIS() ) {
-                        error_log( "$message \n           $file, $line" );
+                    $trace = PHP_EOL . "        " . join( PHP_EOL . "        ", $parts );
+                }
+                $string = sprintf($this->errorLogFormat, $this->errorLog !== 0 ? strftime($this->errorLogTimeFormat) : '', $message, $file, $line, $trace);
+                if ($this->errorLog) $string .= PHP_EOL;
+                
+                if ( ! ErrorHandler::isIIS() ) {
+                    if (is_numeric($this->errorLog)) {
+                        error_log( $string, $this->errorLog );
+                    } elseif (dirname($this->errorLog) && is_dir(dirname($this->errorLog))) {
+                        error_log( $string, 3, $this->errorLog);
+                    } elseif (strpos($this->errorLog, '@') > 0) {
+                        error_log( $string, 1, $this->errorLog );
                     }
                 }
             }


### PR DESCRIPTION
This is just a merge of all my features from the other pull requests with necessary small fixes to make them work together in concert.

Additionally, you get the printout of output until the failure, and support for CLI scripts.

If you want to have consistent and safe error handling across environments, remove `php_error.force_disabled` on production server, and use `'display_errors' = 0` instead. You can also enable rich error messages during runtime, by using `ini_set('display_errors', 1)`.

This way, your users won't see extensive debug information. But you can log all errors in your framework using callbacks, or send yourself an email if you want. And you can display a pretty user-facing error page in case something happens.
