### PR TITLE
ErrorException wasn't compatible with PHP's ErrorException.

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -3965,20 +3965,11 @@
          
         /**
          * This is a carbon copy of \ErrorException.
-         * However that is only supported in PHP 5.1 and above,
-         * so this allows PHP Error to work in PHP 5.0.
-         *
-         * A thin class that wraps up an error, into an exception.
+         * As php_error requires now PHP 5.3, it's left in case anybody tries to catch this
+         * exception class.
          */
-        class ErrorException extends Exception
-        {
-            public function __construct( $message, $code, $severity, $file, $line )
-            {
-                parent::__construct( $message, $code, null );
+        class ErrorException extends \ErrorException {
 
-                $this->file = $file;
-                $this->line = $line;
-            }
         }
 
         /**


### PR DESCRIPTION
Now it's not needed, as php_error requires php 5.3. I've left it for compatibility
