### PR TITLE
fixed Code display when short_open_tag is Off

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -3312,7 +3312,7 @@
                                             data-file-id="<?php echo $fileLinesSet->getHTMLID() ?>"
                                             data-file-src="<?php echo $fileLinesSet->getSrc() ?>"
                                             class="error-editor-file"
-                                    ><?= htmlentities( $fileLinesSet->getContent() ) ?></div><?php
+                                    ><?php echo htmlentities( $fileLinesSet->getContent() ) ?></div><?php
                                 }
                             }
 


### PR DESCRIPTION
Small fix to make code display happend when short_open_tag is not allowed

(btw thanks for this nice library)
