### PR TITLE
'zlib output compression' handler

### DIFF
--- a/src/php_error.php
+++ b/src/php_error.php
@@ -1580,6 +1580,10 @@
                             ob_end_clean();
                         } else if ( $handler === 'default output handler' ) {
                             ob_end_clean();
+                        } else if ( $handler === 'zlib output compression' ) {
+                            if (ob_get_level()) {
+                                while (@ob_end_clean());
+                            }
                         } else {
                             ob_end_flush();
                         }


### PR DESCRIPTION
If you change zlib output compression setting in between ob_start, ob_end_clean or ob_end_flush (Smarty does this)
you will get: ob_end_flush() failed to delete buffer zlib output compression.

Workaround for smarty, added at line 1853: 

 else if ( $handler === 'zlib output compression' ) {
    if (ob_get_level()) {
        while (@ob_end_clean());
    }
 }

![smarty_ob](https://f.cloud.github.com/assets/1819668/1821896/c6aaf312-7146-11e3-888c-046a0bbaa929.jpg)
